### PR TITLE
Add Python 3.12-slim image tag

### DIFF
--- a/images/python
+++ b/images/python
@@ -1,1 +1,2 @@
 latest
+3.12-slim


### PR DESCRIPTION
## Description

This PR adds support for the `3.12-slim` Python image tag to the tracked images. This allows the mirroring workflow to include the slim variant of Python 3.12.

## Type of Change

- [x] Image tag(s) updated
- [ ] New image(s) added
- [ ] Image(s) removed
- [ ] Workflow improvement
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

### For New Images or Tag Updates

- [x] I have verified the image/tags exist on Docker Hub (or specified registry)
- [x] Image name follows the correct format (lowercase, matches Docker Hub exactly)
- [x] For official images: created single file in `images/` directory
- [x] Tags are listed one per line with no comments or special syntax
- [x] File follows `.editorconfig` rules (LF line endings, no trailing whitespace, final newline)
- [x] I tested locally with `find images -type f -printf '%P\n'` to verify the file is detected

### General

- [x] Commit message follows project conventions (descriptive, imperative mood)
- [x] No sensitive information included

## Testing

- [x] Verified image exists on Docker Hub: `python:3.12-slim`
- [x] Confirmed file is properly formatted with one tag per line

## Additional Notes

The `3.12-slim` tag is now tracked alongside the existing `latest` tag for the Python image.

https://claude.ai/code/session_01Ckm26AGkptRKM2PB6Tp9rg