### PR TITLE
mirror: add golang:1.26.3-alpine3.22

### DIFF
--- a/images/golang
+++ b/images/golang
@@ -1,2 +1,3 @@
 latest
 1.26.2-alpine3.22
+1.26.3-alpine3.22


### PR DESCRIPTION
Needed by UCFOP after bumping its go directive to 1.26.3 to clear GO-2026-4971 (stdlib net NUL-byte panic, fixed in 1.26.3).